### PR TITLE
common_fixes.jl: update iter_side_data*

### DIFF
--- a/src/common_fixes.jl
+++ b/src/common_fixes.jl
@@ -103,7 +103,7 @@ const p8est_quadrant_data = quadrant_data
     ############################################
 
 struct full is_ghost::Int8; quad::Ptr{Cvoid}; quadid::p4est_locidx_t; end
-struct hanging{S} is_ghost::NTuple{S,Int8}; quad::Ptr{Cvoid}; quadid::NTuple{S,p4est_locidx_t}; end
+struct hanging{S} is_ghost::NTuple{S,Int8}; quad::NTuple{S,Ptr{Cvoid}}; quadid::NTuple{S,p4est_locidx_t}; end
 iter_side_data_properties = (:full, :hanging)
 
 # Biggest data size in union (24 bytes - 192 bits)
@@ -113,7 +113,7 @@ primitive type iter_side_data_2 8*sizeof(iter_side_data_2_union) end
 function Base.getproperty(x::iter_side_data_2, name::Symbol)
     if name == :full
         _unsafe_reinterpret(full, x)
-    elseif name == :user_long
+    elseif name == :hanging
         _unsafe_reinterpret(hanging{2}, x)
     else
         getfield(x, name)
@@ -135,10 +135,10 @@ const p8est_iter_edge_side_data = iter_side_data_2
 iter_side_data_4_union = Union{full, hanging{4}}
 primitive type iter_side_data_4 8*sizeof(iter_side_data_4_union) end 
 
-function Base.getproperty(x::iter_side_data_4_union, name::Symbol)
+function Base.getproperty(x::iter_side_data_4, name::Symbol)
     if name == :full
         _unsafe_reinterpret(full, x)
-    elseif name == :user_long
+    elseif name == :hanging
         _unsafe_reinterpret(hanging{4}, x)
     else
         getfield(x, name)
@@ -147,5 +147,5 @@ end
 
 Base.propertynames(x::iter_side_data_4) = (iter_side_data_properties..., fieldnames(DataType)...)
 
-const p8est_iter_face_side_data = iter_side_data_4_union
+const p8est_iter_face_side_data = iter_side_data_4
 


### PR DESCRIPTION
These are changes that I needed to be able to use `p4est_iterate()` with a face callback.

The substantive change is changing a `quad::Ptr{Cvoid}` to a tuple `quad::NTuple{S,Ptr{Cvoid}}` in the definition of `struct hanging{S}`. This resolved incorrect data I encountered attempting to load these structs, prompting me to poke into the binary representations. The change also seems to correspond with the layout of p4est or p8est's `hanging` struct [as described here](https://p4est.github.io/api/unionp4est__iter__face__side__t_1_1p4est__iter__face__side__data.html) and [here](https://p4est.github.io/api/unionp8est__iter__face__side__t_1_1p8est__iter__face__side__data.html), respectively.

I made what I think are a couple of other useful fixes, but please check these carefully if merging this PR, as these were mainly motivated by making things consistent between similar definitions in `common_fixes.jl`, not any deep understanding. 

Note that there is a backwards incompatibility being introduced by replacing what I assume is a copy-paste error in accessing the `hanging{S}` data in by the symbol `:user_long` instead of `:hanging`. 

My hope is that these changes will be useful to others in the short term, but I am aware of the open issue #1 - if progress has been made on that front, to allow automatic wrapping of these sorts of structures without the need for `common_fixes.jl` at all, that would of course be exciting!

(P.S. Thank you very much for making this wrapper public in the first place - I found it very helpful and will contribute to it as I can)