### PR TITLE
bumping CEnum compat to 0.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ uuid = "3743d7c0-8adf-11ea-380b-7d33b0ecc1da"
 version = "0.2.3"
 
 [compat]
-CEnum = "0.4"
+CEnum = "0.5"
 MPI = "0.20"
 P4est_jll = "2.3.0"
 julia = "1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ uuid = "3743d7c0-8adf-11ea-380b-7d33b0ecc1da"
 version = "0.2.3"
 
 [compat]
-CEnum = "0.5"
+CEnum = "0.4, 0.5"
 MPI = "0.20"
 P4est_jll = "2.3.0"
 julia = "1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 authors = ["Victor Sande <vsande@cimne.upc.edu>", "Alberto F. Martin <alberto.f.martin@anu.edu.au>"]
 name = "P4est_wrapper"
 uuid = "3743d7c0-8adf-11ea-380b-7d33b0ecc1da"
-version = "0.2.3"
+version = "0.2.4"
 
 [compat]
 CEnum = "0.4, 0.5"


### PR DESCRIPTION
Some packages like [CUDSS.jl](https://github.com/exanauts/CUDSS.jl) restrict `CEnum.jl` compat to 0.5 and above, and this is causing a compat resolving issue.

For reference, the CI check for compatibility with `GridapP4est.jl` is [here](https://github.com/gridap/GridapP4est.jl/tree/check-cenum-0.5-p4est_wrapper) 